### PR TITLE
add CNAME automation and project submission issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/project_submission.yml
+++ b/.github/ISSUE_TEMPLATE/project_submission.yml
@@ -1,0 +1,54 @@
+name: "Project Submission"
+description: "Share your DevOpsDiary project solution"
+title: "[SUBMIT] ${{project_title}}"
+labels: ["project submission"]
+body:
+  - type: input
+    id: project_title
+    attributes:
+      label: "Project Title"
+      description: 'e.g. "Git Basics"'
+      placeholder: "Enter the project title"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: level
+    attributes:
+      label: "Level"
+      description: "Select your difficulty level"
+      options:
+        - Beginner
+        - Intermediate
+        - Advanced
+    validations:
+      required: true
+
+  - type: input
+    id: devopsdiary_link
+    attributes:
+      label: "DevOpsDiary Project Page Link"
+      description: "e.g. https://devopsdiary.site/beginner/01_git_basics"
+      placeholder: "https://devopsdiary.site/..."
+    validations:
+      required: true
+
+  - type: input
+    id: repository_link
+    attributes:
+      label: "Repository Link"
+      description: "Link to your solution repo or folder"
+      placeholder: "https://github.com/your-username/..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description of Your Approach"
+      description: "Summarize what you did and how"
+      placeholder: |
+        - Initialized a repo with `git init`.
+        - Created and merged branches using `git branch` and `git merge`.
+    validations:
+      required: true

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,6 +67,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: gh-pages
+          cname: devopsdiary.site
 
       - name: Deploy Preview to GitHub Pages (develop)
         if: github.ref == 'refs/heads/develop'
@@ -75,4 +76,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: gh-pages-preview
+          cname: devopsdiary.site
           destination_dir: develop


### PR DESCRIPTION
### What was done

- ✅ Updated CI/CD pipeline to automatically create CNAME file for:
  - `gh-pages` (production) with domain `devopsdiary.site`
  - `gh-pages-preview` (develop) with subpath support
- ✅ Added GitHub issue template for project submissions:
  - Includes fields like title, level, project link, repo URL, and description
  - Supports submission via URL parameters

### Why this is important

- Ensures the custom domain works on both production and preview environments.
- Helps users submit project solutions clearly and consistently.
